### PR TITLE
Use logging instead of prints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To use it as a package:
 ```py
 import pdftotree
 
-pdftotree.parse(pdf_file, html_path, model_path=None, favor_figures=True, visualize=False):
+pdftotree.parse(pdf_file, html_path=None, model_path=None, favor_figures=True, visualize=False):
 ```
 
 ## For Developers

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the commandline tool:
 ```
 usage: extract_tree [-h] [--model_path MODEL_PATH] --pdf_file PDF_FILE
                     [--html_path HTML_PATH] [--favor_figures FAVOR_FIGURES]
-                    [--visualize]
+                    [--visualize] [-v] [-vv]
 
 Script to extract tree structure from PDF files.
 
@@ -39,11 +39,14 @@ optional arguments:
   --pdf_file PDF_FILE   pdf file name for which tree structure needs to be
                         extracted
   --html_path HTML_PATH
-                        path where tree structure must be saved
+                        path where tree structure should be saved. If none,
+                        HTML is printed to stdout.
   --favor_figures FAVOR_FIGURES
                         whether figures must be favored over other parts such
                         as tables and section headers
   --visualize           whether to output visualization images for the tree
+  -v                    output INFO level logging.
+  -vv                   output DEBUG level logging.
 ```
 
 To use it as a package:

--- a/bin/extract_tree
+++ b/bin/extract_tree
@@ -67,5 +67,7 @@ if __name__ == '__main__':
     result = pdftotree.parse(args.pdf_file, args.html_path, args.model_path,
                              args.favor_figures, args.visualize)
 
-    if args.html_path is None:
+    if result:
         print(result)
+    else:
+        print("HTML output to {}".format(args.html_path))

--- a/bin/extract_tree
+++ b/bin/extract_tree
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Simple commandline interface for parsing PDF to HTML."""
 import argparse
+import logging
 import pdftotree
 
 if __name__ == '__main__':
@@ -16,8 +17,9 @@ if __name__ == '__main__':
     parser.add_argument(
         '--html_path',
         type=str,
-        help='path where tree structure must be saved',
-        default="./results/")
+        help=
+        'path where tree structure should be saved. If none, HTML is printed to stdout.'
+    )
     parser.add_argument(
         '--favor_figures',
         type=str,
@@ -29,9 +31,41 @@ if __name__ == '__main__':
         dest="visualize",
         action="store_true",
         help='whether to output visualization images for the tree')
+    parser.add_argument(
+        '-v',
+        dest="verbose",
+        action="store_true",
+        help='output INFO level logging.')
+    parser.add_argument(
+        '-vv',
+        dest="debug",
+        action="store_true",
+        help='output DEBUG level logging.')
     parser.set_defaults(visualize=False)
     args = parser.parse_args()
 
+    if args.debug:
+        log_level = logging.DEBUG
+    elif args.verbose:
+        log_level = logging.INFO
+    else:
+        log_level = logging.ERROR
+
+    # Configure logging for this application
+    log = logging.getLogger('pdftotree')
+    log.setLevel(log_level)
+
+    ch = logging.StreamHandler()
+    ch.setLevel(log_level)
+
+    formatter = logging.Formatter("[%(levelname)s] %(name)s - %(message)s")
+    ch.setFormatter(formatter)
+
+    log.addHandler(ch)
+
     # Call the main routine
-    pdftotree.parse(args.pdf_file, args.html_path, args.model_path,
-                    args.favor_figures, args.visualize)
+    result = pdftotree.parse(args.pdf_file, args.html_path, args.model_path,
+                             args.favor_figures, args.visualize)
+
+    if args.html_path is None:
+        print(result)

--- a/pdftotree/TreeExtract.py
+++ b/pdftotree/TreeExtract.py
@@ -1,21 +1,22 @@
-import six  # Python 2-3 compatibility
+import json
+import logging
 import numpy as np
 import re
-from functools import cmp_to_key
-
-from pdftotree.utils.bbox_utils import get_rectangles, compute_iou
-from pdftotree.utils.lines_utils import reorder_lines, get_vertical_and_horizontal, extend_vertical_lines, \
-    merge_vertical_lines, merge_horizontal_lines, extend_horizontal_lines
-from pdftotree.pdf.pdf_parsers import parse_layout, parse_tree_structure, get_figures
-from pdftotree.pdf.pdf_utils import normalize_pdf, analyze_pages
-from pdftotree.utils.display_utils import pdf_to_img
-from pdftotree.ml.features import get_alignment_features, get_lines_features, get_mentions_within_bbox
-from wand.color import Color
-from wand.drawing import Drawing
-from pdfminer.utils import Plane
+import six  # Python 2-3 compatibility
 import tabula
-import json
+from functools import cmp_to_key
+from pdfminer.utils import Plane
+from pdftotree.ml.features import get_lines_features, get_mentions_within_bbox
 from pdftotree.pdf.layout_utils import *
+from pdftotree.pdf.pdf_parsers import parse_layout, parse_tree_structure
+from pdftotree.pdf.pdf_utils import normalize_pdf, analyze_pages
+from pdftotree.utils.bbox_utils import get_rectangles
+from pdftotree.utils.lines_utils import extend_horizontal_lines
+from pdftotree.utils.lines_utils import extend_vertical_lines
+from pdftotree.utils.lines_utils import get_vertical_and_horizontal
+from pdftotree.utils.lines_utils import merge_horizontal_lines
+from pdftotree.utils.lines_utils import merge_vertical_lines
+from pdftotree.utils.lines_utils import reorder_lines
 
 class TreeExtractor(object):
     """
@@ -23,6 +24,7 @@ class TreeExtractor(object):
     """
 
     def __init__(self, pdf_file):
+        self.log = logging.getLogger(__name__)
         self.pdf_file = pdf_file
         self.elems = {}
         self.font_stats = {}
@@ -146,7 +148,7 @@ class TreeExtractor(object):
         try:
             nodes, features = parse_layout(elems, font_stat)
         except Exception as e:
-            print(e)
+            self.log.execption(e)
             nodes, features = [], []
         return [(page_num, page_width, page_height) + (node.y0, node.x0,
                 node.y1, node.x1) for node in nodes], features
@@ -252,7 +254,7 @@ class TreeExtractor(object):
                     char_idx += 1
                     continue
                 if word[len_idx] != mention_chars[char_idx][0]:
-                    print("Out of order", word, mention_chars[char_idx][0])
+                    self.log.warning("Out of order", word, mention_chars[char_idx][0])
                 curr_word[1] = min(curr_word[1], mention_chars[char_idx][1])
                 curr_word[2] = min(curr_word[2], mention_chars[char_idx][2])
                 curr_word[3] = max(curr_word[3], mention_chars[char_idx][3])

--- a/pdftotree/__init__.py
+++ b/pdftotree/__init__.py
@@ -1,3 +1,7 @@
 #!/usr/bin/env python
 
-from .core import parse
+# At the top level, prevent logging output in absense of logging config.
+import logging
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+from pdftotree.core import parse

--- a/pdftotree/core.py
+++ b/pdftotree/core.py
@@ -54,11 +54,11 @@ def parse(pdf_file,
         model = load_model(model_path)
     extractor = TreeExtractor(pdf_file)
     if (not extractor.is_scanned()):
-        log.info("Digitized PDF detected, building tree structure")
+        log.info("Digitized PDF detected, building tree structure...")
         pdf_tree = extractor.get_tree_structure(model, favor_figures)
-        log.info("Tree structure built, creating html")
+        log.info("Tree structure built, creating html...")
         pdf_html = extractor.get_html_tree()
-        log.info("HTML created, writing to file")
+        log.info("HTML created, outputting...")
         pdf_filename = os.path.basename(pdf_file)
         # Check html_path exists, create if not
         pdf_html = re.sub(r'[\x00-\x1F]+', '', pdf_html)

--- a/pdftotree/ml/extract_tables.py
+++ b/pdftotree/ml/extract_tables.py
@@ -1,26 +1,36 @@
+from __future__ import print_function
+from builtins import str
+from builtins import range
 import argparse
+import logging
+import numpy as np
 import os
 import pickle
 import sys
-
-import numpy as np
-from ml.TableExtractML import TableExtractorML
-from sklearn import linear_model, preprocessing, metrics
-from utils.bbox_utils import doOverlap, compute_iou, isContained
 from tesseract.table_extractor import extract_tables
+
+from sklearn import linear_model, preprocessing, metrics
+from ml.TableExtractML import TableExtractorML
+from utils.bbox_utils import doOverlap, compute_iou, isContained
+
+log = logging.getLogger(__name__)
+
 
 def get_bboxes_from_line(line):
     if line == "NO_TABLES":
         return {}
     bboxes = {}
     for bbox in line.split(";"):
-        page_num, page_width, page_height, y0, x0, y1, x1 = bbox[1:-1].split(",")
+        page_num, page_width, page_height, y0, x0, y1, x1 = bbox[1:-1].split(
+            ",")
         try:
-            bboxes[int(page_num)] += [
-                (float(page_width), float(page_height), float(y0), float(x0), float(y1), float(x1))]
+            bboxes[int(page_num)] += [(float(page_width), float(page_height),
+                                       float(y0), float(x0), float(y1),
+                                       float(x1))]
         except KeyError:
-            bboxes[int(page_num)] = [
-                (float(page_width), float(page_height), float(y0), float(x0), float(y1), float(x1))]
+            bboxes[int(page_num)] = [(float(page_width), float(page_height),
+                                      float(y0), float(x0), float(y1),
+                                      float(x1))]
     return bboxes
 
 
@@ -30,7 +40,8 @@ def get_features_and_labels(pdf_list, gt_list):
     tables = []
     for i, pdf_file in enumerate(pdf_files):
         if i % 10 == 0:
-            print "{} documents processed out of {}".format(i, len(pdf_files))
+            log.info("{} documents processed out of {}".format(
+                i, len(pdf_files)))
         gt_tables = get_bboxes_from_line(gt[i])
         extractor = TableExtractorML(os.environ['DATAPATH'] + pdf_file)
         bboxes, features, is_scanned = extractor.get_candidates_and_features()
@@ -45,20 +56,20 @@ def get_features_and_labels(pdf_list, gt_list):
             y = np.concatenate((y, labels), axis=0)
             tables = np.concatenate((tables, bboxes), axis=0)
     X = preprocessing.scale(X, axis=0)
-    print "Features computed!"
+    log.info("Features computed!")
     return X, y, tables
 
 
 def load_train_data(pdf_list, gt_list):
     if os.path.exists(pdf_list + '.features.pkl'):
-        print "Loading precomputed features for {}..".format(pdf_list)
+        log.info("Loading precomputed features for {}..".format(pdf_list))
         # load pickled data
         X = pickle.load(open(pdf_list + '.features.pkl', 'rb'))
         y = pickle.load(open(pdf_list + '.labels.pkl', 'rb'))
         tables = pickle.load(open(pdf_list + '.candidates.pkl', 'rb'))
-        print "Features loaded!"
+        log.info("Features loaded!")
     else:
-        print "Building feature matrix for {}".format(pdf_list)
+        log.info("Building feature matrix for {}".format(pdf_list))
         # compute and pickle feature matrix
         X, y, tables = get_features_and_labels(pdf_list, gt_list)
         pickle.dump(X, open(pdf_list + '.features.pkl', 'wb'))
@@ -75,51 +86,62 @@ def get_features(pdf_list):
     scanned_tables = {}
     for i, pdf_file in enumerate(pdf_files):
         if i % 10 == 0:
-            print "{} documents processed out of {}".format(i, len(pdf_files))
+            log.info("{} documents processed out of {}".format(
+                i, len(pdf_files)))
         extractor = TableExtractorML(os.environ['DATAPATH'] + pdf_file)
         bboxes, features, is_scanned = extractor.get_candidates_and_features()
-        if(is_scanned):
+        if (is_scanned):
             #document is scanned
             scanned_indices.append(i)
-            if not os.path.exists(os.environ['DATAPATH']+"tesseract_results"):
-                os.makedirs(os.environ['DATAPATH']+"tesseract_results")
-            if not os.path.exists(os.environ['DATAPATH']+"tesseract_results/"+pdf_file):
-                os.system("./../tesseract/preprocess.sh "+os.environ['DATAPATH']+"tesseract_results/"+pdf_file+" "+os.environ['DATAPATH']+pdf_file)
+            if not os.path.exists(
+                    os.environ['DATAPATH'] + "tesseract_results"):
+                os.makedirs(os.environ['DATAPATH'] + "tesseract_results")
+            if not os.path.exists(
+                    os.environ['DATAPATH'] + "tesseract_results/" + pdf_file):
+                os.system("./../tesseract/preprocess.sh " +
+                          os.environ['DATAPATH'] + "tesseract_results/" +
+                          pdf_file + " " + os.environ['DATAPATH'] + pdf_file)
             try:
-                scanned_tables[i] = extract_tables(os.environ['DATAPATH']+"tesseract_results/"+pdf_file+"/")
+                scanned_tables[
+                    i] = extract_tables(os.environ['DATAPATH'] +
+                                        "tesseract_results/" + pdf_file + "/")
             except:
                 scanned_tables[i] = "NO_TABLES\n"
             continue
         bboxes = [[i] + list(bbox) for bbox in bboxes]
-        if len(X)==0:
+        if len(X) == 0:
             X = np.array(features)
             tables = np.array(bboxes)
         else:
             X = np.concatenate((X, np.array(features)), axis=0)
             tables = np.concatenate((tables, bboxes), axis=0)
-    if(len(X)>0):
+    if (len(X) > 0):
         X = preprocessing.scale(X, axis=0)
-    print "Features computed!"
+    log.info("Features computed!")
     return X, tables, scanned_indices, scanned_tables
 
 
 def load_test_data(pdf_list):
     if os.path.exists(pdf_list + '.features.pkl'):
-        print "Loading precomputed features for {}..".format(pdf_list)
+        log.info("Loading precomputed features for {}..".format(pdf_list))
         # load pickled data
         X = pickle.load(open(pdf_list + '.features.pkl', 'rb'))
         tables = pickle.load(open(pdf_list + '.candidates.pkl', 'rb'))
-        scanned_indices = pickle.load(open(pdf_list + '.scanned_indices.pkl', 'rb'))
-        scanned_tables = pickle.load(open(pdf_list + '.scanned_tables.pkl', 'rb'))
-        print "Features loaded!"
+        scanned_indices = pickle.load(
+            open(pdf_list + '.scanned_indices.pkl', 'rb'))
+        scanned_tables = pickle.load(
+            open(pdf_list + '.scanned_tables.pkl', 'rb'))
+        log.info("Features loaded!")
     else:
-        print "Building feature matrix for {}".format(pdf_list)
+        log.info("Building feature matrix for {}".format(pdf_list))
         # compute and pickle feature matrix
         X, tables, scanned_indices, scanned_tables = get_features(pdf_list)
         pickle.dump(X, open(pdf_list + '.features.pkl', 'wb'))
         pickle.dump(tables, open(pdf_list + '.candidates.pkl', 'wb'))
-        pickle.dump(scanned_indices, open(pdf_list + '.scanned_indices.pkl', 'wb'))
-        pickle.dump(scanned_tables, open(pdf_list + '.scanned_tables.pkl', 'wb'))
+        pickle.dump(scanned_indices,
+                    open(pdf_list + '.scanned_indices.pkl', 'wb'))
+        pickle.dump(scanned_tables, open(pdf_list + '.scanned_tables.pkl',
+                                         'wb'))
     return X, tables.astype(np.int), scanned_indices, scanned_tables
 
 
@@ -130,7 +152,8 @@ def compute_overlap_matrix(pdf_bboxes, iou_thresh):
         for j, bb2 in enumerate(pdf_bboxes):
             if i != j and bb1[0] == bb2[0] and doOverlap(bb1[-4:], bb2[-4:]):
                 iou = compute_iou(bb1[-4:], bb2[-4:])
-                if iou > iou_thresh or isContained(bb1[-4:], bb2[-4:]) or isContained(bb2[-4:], bb1[-4:]):
+                if iou > iou_thresh or isContained(
+                        bb1[-4:], bb2[-4:]) or isContained(bb2[-4:], bb1[-4:]):
                     overlap[i, j] = 1.
     return overlap
 
@@ -169,29 +192,33 @@ def compute_stats(y_pred, y_test):
     recall = metrics.recall_score(y_test, y_pred)
     precision = metrics.precision_score(y_test, y_pred)
     accuracy = metrics.accuracy_score(y_test, y_pred)
-    print "Classification Metrics:"
-    print "(Note that these statistics are not for the table detection task but for the classification problem."
-    print "To run evaluation for the table detection class, refer to the script char_level_evaluation.py)"
-    print "Precision: ", precision
-    print "Recall: ", recall
-    print "F1-score: ", 2 * precision * recall / (precision + recall)
-    print "Accuracy:", accuracy
+    log.info("Classification Metrics:")
+    log.info(
+        "(Note that these statistics are not for the table detection task but for the classification problem."
+    )
+    log.info(
+        "To run evaluation for the table detection class, refer to the script char_level_evaluation.py)"
+    )
+    log.info("Precision: ", precision)
+    log.info("Recall: ", recall)
+    log.info("F1-score: ", 2 * precision * recall / (precision + recall))
+    log.info("Accuracy:", accuracy)
 
 
 def train_model(X_train, y_train, model_path):
-    print "Training model..."
+    log.info("Training model...")
     logistic = linear_model.LogisticRegression()
     logistic.fit(X_train, y_train)
-    print "Model trained!"
+    log.info("Model trained!")
     pickle.dump(logistic, open(model_path, 'wb'))
-    print "Model saved!"
+    log.info("Model saved!")
     return logistic
 
 
 def load_model(model_path):
-    print "Loading pretrained model..."
+    log.info("Loading pretrained model...")
     model = pickle.load(open(model_path, 'rb'))
-    print "Model loaded!"
+    log.info("Model loaded!")
     return model
 
 
@@ -209,6 +236,7 @@ def filter_bboxes(tables, iou_thresh):
             bboxes = [tuple(table[1:])]
     return pdf_idx_to_filtered_bboxes
 
+
 def bbox_to_dict(tables):
     bbox_dict = {}
     for table in tables:
@@ -218,14 +246,17 @@ def bbox_to_dict(tables):
             bbox_dict[table[0]] = [tuple(table[1:])]
     return bbox_dict
 
-def write_bbox_to_file(bbox_file, pdf_idx_to_filtered_bboxes, num_test, scanned_test, scanned_tables):
+
+def write_bbox_to_file(bbox_file, pdf_idx_to_filtered_bboxes, num_test,
+                       scanned_test, scanned_tables):
     for i in range(num_test):
-        if(i in scanned_test):
+        if (i in scanned_test):
             bbox_file.write(scanned_tables[i])
             continue
         try:
             filtered_bboxes = pdf_idx_to_filtered_bboxes[i]
-            bbox_file.write(";".join([str(bbox) for bbox in filtered_bboxes]) + "\n")
+            bbox_file.write(";".join([str(bbox)
+                                      for bbox in filtered_bboxes]) + "\n")
         except KeyError:
             bbox_file.write("NO_TABLES\n")
     bbox_file.close()
@@ -233,49 +264,81 @@ def write_bbox_to_file(bbox_file, pdf_idx_to_filtered_bboxes, num_test, scanned_
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-            description="""Script to extract tables bounding boxes from PDF files using a machine learning approach.
+        description=
+        """Script to extract tables bounding boxes from PDF files using a machine learning approach.
             if model.pkl is saved in the model-path, the pickled model will be used for prediction. Otherwise the model will be retrained.
             If --mode is test (by default), the script will create a .bbox file containing the tables for the pdf documents listed in the file --test-pdf.
             If --mode is dev, the script will also extract ground truth labels fot the test data and compute some statistics.
-            To run the script on new documents, specify the path to the list of pdf to analyze using the argument --test-pdf. Those files must be saved in the DATAPATH folder.""")
-    parser.add_argument('--mode', type=str, default='test', help='usage mode dev or test, default is test')
-    parser.add_argument('--train-pdf', type=str, default=os.environ['MLPATH'] + 'train.pdf.list.paleo.not.scanned',
-                        help='list of pdf file names used for training. Those files must be saved in the DATAPATH folder (cf set_env.sh)')
-    parser.add_argument('--test-pdf', type=str, default=os.environ['MLPATH'] + 'test.pdf.list.paleo.not.scanned',
-                        help='list of pdf file names used for testing. Those files must be saved in the DATAPATH folder (cf set_env.sh)')
-    parser.add_argument('--gt-train', type=str, default=os.environ['MLPATH'] + 'gt.train',
-                        help='ground truth train tables')
-    parser.add_argument('--gt-test', type=str, default=os.environ['MLPATH'] + 'gt.test',
-                        help='ground truth test tables')
-    parser.add_argument('--model-path', type=str, default=os.environ['MLPATH'] + 'model.pkl', help='pretrained model')
-    parser.add_argument('--iou-thresh', type=float, default=0.8,
-                        help='intersection over union threshold to remove duplicate tables')
+            To run the script on new documents, specify the path to the list of pdf to analyze using the argument --test-pdf. Those files must be saved in the DATAPATH folder."""
+    )
+    parser.add_argument(
+        '--mode',
+        type=str,
+        default='test',
+        help='usage mode dev or test, default is test')
+    parser.add_argument(
+        '--train-pdf',
+        type=str,
+        default=os.environ['MLPATH'] + 'train.pdf.list.paleo.not.scanned',
+        help=
+        'list of pdf file names used for training. Those files must be saved in the DATAPATH folder (cf set_env.sh)'
+    )
+    parser.add_argument(
+        '--test-pdf',
+        type=str,
+        default=os.environ['MLPATH'] + 'test.pdf.list.paleo.not.scanned',
+        help=
+        'list of pdf file names used for testing. Those files must be saved in the DATAPATH folder (cf set_env.sh)'
+    )
+    parser.add_argument(
+        '--gt-train',
+        type=str,
+        default=os.environ['MLPATH'] + 'gt.train',
+        help='ground truth train tables')
+    parser.add_argument(
+        '--gt-test',
+        type=str,
+        default=os.environ['MLPATH'] + 'gt.test',
+        help='ground truth test tables')
+    parser.add_argument(
+        '--model-path',
+        type=str,
+        default=os.environ['MLPATH'] + 'model.pkl',
+        help='pretrained model')
+    parser.add_argument(
+        '--iou-thresh',
+        type=float,
+        default=0.8,
+        help='intersection over union threshold to remove duplicate tables')
     args = parser.parse_args()
     # load or train the model
     if os.path.exists(args.model_path):
         model = load_model(args.model_path)
     else:
-        X_train, y_train, tables_train = load_train_data(args.train_pdf, args.gt_train)
+        X_train, y_train, tables_train = load_train_data(
+            args.train_pdf, args.gt_train)
         model = train_model(X_train, y_train, args.model_path)
     num_test = len(open(args.test_pdf).readlines())
     if args.mode == 'dev':
         # load dev data (with ground truth, for evaluation)
-        X_test, y_test, tables_test = load_train_data(args.test_pdf, args.gt_test)
+        X_test, y_test, tables_test = load_train_data(args.test_pdf,
+                                                      args.gt_test)
         # predict tables for dev tables and evaluate
         y_pred = model.predict(X_test)
-        print "Testing for {} pdf documents".format(num_test)
+        log.info("Testing for {} pdf documents".format(num_test))
         compute_stats(y_pred, y_test)
     elif args.mode == 'test':
         # load test data (with no ground truth)
-        X_test, tables_test, scanned_test, scanned_tables = load_test_data(args.test_pdf)
-        if(len(X_test) == 0):   #all docs are scanned
+        X_test, tables_test, scanned_test, scanned_tables = load_test_data(
+            args.test_pdf)
+        if (len(X_test) == 0):  #all docs are scanned
             y_pred = []
         else:
             y_pred = model.predict(X_test)
     else:
-        print "Mode not recognized, pick dev or test."
+        log.error("Mode not recognized, pick dev or test.")
         sys.exit()
-    if(len(y_pred) != 0):
+    if (len(y_pred) != 0):
         predicted_tables = tables_test[np.flatnonzero(y_pred)]
         # todo: remove duplicate tables
         # pdf_idx_to_filtered_bboxes = filter_bboxes(predicted_tables, args.iou_thresh)
@@ -284,4 +347,5 @@ if __name__ == '__main__':
     else:
         pdf_idx_to_filtered_bboxes = []
     bbox_file = open(args.test_pdf + '.bbox', 'w')
-    write_bbox_to_file(bbox_file, pdf_idx_to_filtered_bboxes, num_test, scanned_test, scanned_tables)
+    write_bbox_to_file(bbox_file, pdf_idx_to_filtered_bboxes, num_test,
+                       scanned_test, scanned_tables)

--- a/pdftotree/pdf/grid.py
+++ b/pdftotree/pdf/grid.py
@@ -3,15 +3,15 @@ Created on Dec 2, 2015
 
 @author: xiao
 '''
-import numpy as np
 import bisect
-from pdfminer.utils import Plane
+import logging
+import numpy as np
 import pandas as pd
-from pdftotree.pdf.vector_utils import inside, reading_order
-from pdftotree.pdf.layout_utils import project_onto
 from collections import defaultdict
 from functools import cmp_to_key
-from pprint import pprint
+from pdfminer.utils import Plane
+from pdftotree.pdf.vector_utils import inside, reading_order
+from pprint import pformat
 
 class Cell(object):
     '''Represents a cell with no visual dividers inside'''
@@ -90,11 +90,8 @@ class Grid(object):
             bbox = (x0, y0, x1, y1)
             # Keep mentions whose centers are inside the cell
             cell.texts = [m for m in text_plane.find(bbox) if inside(bbox, (m.xc, m.yc) * 2)]
-#             print (cell.rowstart, cell.colstart, cell.rowend, cell.colend), cell
 
-# TODO: provide HTML conversion here
-#         df = pd.DataFrame(grid)
-#         print df.to_string(index=False, header=False)
+        # TODO: provide HTML conversion here
 
         self.get_normalized_grid()
 
@@ -104,10 +101,11 @@ class Grid(object):
     def to_html(self):
         return self.to_dataframe().to_html(index=False, header=False)
 
-    def get_normalized_grid(self, debug_print = False):
+    def get_normalized_grid(self):
         '''
         Analyzes subcell structure
         '''
+        log = logging.getLogger(__name__)
         # Resolve multirow mentions, TODO: validate against all PDFs
         subcol_count = 0;
         mega_rows = []
@@ -119,20 +117,16 @@ class Grid(object):
                 cell.texts.sort(key=cmp_to_key(reading_order))
 #                intervals, groups = project_onto(cell.texts, axis='x', self.min_cell_size)
                 prev = None
-                if debug_print:
-                    print('='*50)
+                log.debug('='*50)
                 for m in cell.texts:
-#                     print m.yc_grid, m.clean_text
                     subrow_across_cell[m.yc_grid].append(m)
                     prev = m
 
-            if debug_print:
-                pprint(dict(subrow_across_cell))
+            log.debug(pformat(dict(subrow_across_cell)))
 
             mega_rows.append(subrow_across_cell)
 
-            #pprint(dict(subrow_across_cell), indent=1)
-        # Multilnie paragraph check
+        # Multiline paragraph check
         # Subrow/Subcolumn
 
         return mega_rows

--- a/pdftotree/pdf/layout_utils.py
+++ b/pdftotree/pdf/layout_utils.py
@@ -3,11 +3,14 @@ Created on Jan 25, 2016
 
 @author: xiao
 '''
-from pdftotree.pdf.vector_utils import *
 import collections
-from pdfminer.layout import LTTextLine, LTChar, LTAnno, LTCurve, LTComponent, LTLine
-from itertools import chain
+import logging
 import numpy as np
+from itertools import chain
+from pdfminer.layout import LTTextLine, LTChar, LTAnno, LTCurve, LTComponent, LTLine
+from pdftotree.pdf.vector_utils import *
+
+log = logging.getLogger(__name__)
 
 def traverse_layout(root, callback):
     '''
@@ -198,7 +201,7 @@ def recursive_xy_divide(elems, avg_font_size):
     avg_font_size: the minimum gap size between elements below
     which we consider interval continuous.
     '''
-    print(avg_font_size)
+    log.info(avg_font_size)
     objects = list(elems.mentions)
     objects.extend(elems.segments)
     bboxes = []
@@ -228,8 +231,7 @@ def recursive_xy_divide(elems, avg_font_size):
             return objs
         else:
             children = []
-#             print 'dividing y' if h_split else 'dividing x', 'into', len(groups), 'groups'
-#             is_text_block = [all(isinstance(o, LTTextLine) for o in g) for g in groups]
+
             for interval, group in izip(intervals, groups):
                 # Create the bbox for the subgroup
                 sub_bbox = np.array(bbox)
@@ -242,7 +244,7 @@ def recursive_xy_divide(elems, avg_font_size):
     full_page_bbox = (0, 0, elems.layout.width, elems.layout.height)
     # Filter out invalid objects
     objects = [o for o in objects if inside(full_page_bbox,o.bbox)]
-    print('avg_font_size for dividing', avg_font_size)
+    log.info('avg_font_size for dividing', avg_font_size)
     tree = divide(objects, full_page_bbox) if objects else []
     return bboxes, tree
 

--- a/pdftotree/pdf/pdf_parsers.py
+++ b/pdftotree/pdf/pdf_parsers.py
@@ -4,16 +4,18 @@ Parsing raw PDF data into python data structures
 
 @author: xiao
 '''
+import logging
+import math
+import operator
 import six  # Python 2-3 compatibility
 from collections import defaultdict
+from copy import deepcopy
 from functools import cmp_to_key
-
 from pdfminer.utils import Plane
 from pdftotree.pdf.layout_utils import *
 from pdftotree.pdf.node import Node
-import operator
-from copy import deepcopy
-import math
+
+log = logging.getLogger(__name__)
 
 def parse_layout(elems, font_stat, combine=False):
     '''
@@ -442,8 +444,6 @@ def cluster_vertically_aligned_boxes(boxes, page_bbox, avg_font_pts, width, char
     clusters = [[boxes[i] for i in cluster] for cluster in filter(bool, cid2obj2)]
     nodes = [Node(elems) for elems in clusters]
     node_indices = [i for i, x in enumerate(cid2obj2) if x]
-    # for idx in range(len(nodes)):
-    #     print idx, node_indices[idx], nodes[idx]
     merge_indices = [i for i in range(len(node_indices))]
     page_stat = Node(boxes)
     nodes, merge_indices = merge_nodes(nodes, plane, page_stat, merge_indices)
@@ -636,7 +636,6 @@ def parse_tree_structure(elems, font_stat, page_num, ref_page_seen, tables, favo
         intersect = False
         for idx2, table in enumerate(tables_page):
             table_box = tuple(table[3:])
-            # print , box.bbox
             bool_overlap = (table_box[1] <= box.bbox[2] and box.bbox[0] <= table_box[3] and table_box[0] <= box.bbox[3] and box.bbox[1] <= table_box[2])
             if(bool_overlap):
                 intersect = True
@@ -847,7 +846,7 @@ def extract_text_candidates(boxes, page_bbox, avg_font_pts, width, char_width, p
         min_y_page = min(min_y_page, box.bbox[1])
     if page_num == -1:
         #handle title, authors and abstract here
-        print("todo")
+        log.error("TODO: no way to handle title authors abstract yet.")
     else:
         #eliminate header, footer, page number
         #sort other text and classify as header/paragraph

--- a/pdftotree/pdf/pdf_utils.py
+++ b/pdftotree/pdf/pdf_utils.py
@@ -5,14 +5,12 @@ extracted with PDFminer
 
 @author: xiao
 '''
-import six  # Python 2+3 compatibility
-
+import logging
 import os
 import re
+import six  # Python 2+3 compatibility
 import string
-import traceback
 from collections import Counter
-
 from pdftotree.img_utils import *
 from pdftotree.pdf.vector_utils import *
 from pdfminer.converter import PDFPageAggregator
@@ -26,6 +24,8 @@ from pdftotree.pdf.layout_utils import *
 
 # Compact wrapper representation for the pdf
 PDFElems = namedtuple('PDFElems', ['mentions', 'segments', 'curves', 'figures', 'layout', 'chars'])
+
+log = logging.getLogger(__name__)
 
 
 class CustomPDFPageAggregator(PDFPageAggregator):
@@ -116,8 +116,7 @@ def analyze_pages(file_name, char_margin=1.0):
             try:
                 interpreter.process_page(page)
             except OverflowError as oe:
-                print(oe, ', skipping page', page_num, 'of', file_name)
-                traceback.print_exc()
+                log.execption(oe, ', skipping page', page_num, 'of', file_name)
                 continue
             layout = device.get_result()
             yield layout

--- a/pdftotree/pdf/render.py
+++ b/pdftotree/pdf/render.py
@@ -6,8 +6,9 @@ Created on Jan 28, 2016
 
 @author: xiao
 '''
-import numpy as np
 from pdf.vector_utils import *
+import logging
+import numpy as np
 
 class Renderer(object):
     '''
@@ -28,6 +29,7 @@ class Renderer(object):
         scaler so we can map original coordinates into the
         new grid map.
         '''
+        self.log = logging.getLogger(__name__)
         self.scaler = scaler
         layout = elems.layout
         width = int(np.ceil(scaler * layout.width))
@@ -36,7 +38,7 @@ class Renderer(object):
         self.grid = np.zeros((width, height), dtype = np.int8)
 
         # Estimates the grid size in megabytes
-        print self.grid.nbytes/float(1048576)
+        self.log.info(self.grid.nbytes/float(1048576))
         for line in elems.segments:
             if line.height < 0.1:  # Horizontal lines
                 self.draw_rect(line.bbox, self.horizontal_line)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 IPython
 beautifulsoup4
 bintrees
+future
 lxml
 numpy
 pandas

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pdftotree',
-    version='0.1.2',
+    version='0.1.3',
     description='Parse PDFs into HTML-like trees.',
     packages=find_packages(),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         'IPython',
         'beautifulsoup4',
         'bintrees',
+        'future',
         'lxml',
         'numpy',
         'pandas',

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,15 +6,13 @@ from tests.context import pdftotree
 
 def test_heuristic_completion():
     """Simply test that parse runs to completion without errors."""
-    output = pdftotree.parse("tests/input/paleo.pdf", "tests/output/",
-                             debug=True)
+    output = pdftotree.parse("tests/input/paleo.pdf")
     assert output is not None
 
 
-@pytest.mark.skipif(sys.version_info > (2,7), reason="Only runs on Python2.")
+@pytest.mark.skipif(sys.version_info > (2, 7), reason="Only runs on Python2.")
 def test_ml_completion():
     """Simply test that ML-based parse runs without errors."""
-    output = pdftotree.parse("tests/input/paleo.pdf", "tests/output/",
-                             model_path="tests/input/paleo_model.pkl",
-                             debug=True)
+    output = pdftotree.parse(
+        "tests/input/paleo.pdf", model_path="tests/input/paleo_model.pkl")
     assert output is not None


### PR DESCRIPTION
This PR switches to logging for all output rather than print statements (closes #6). It also changes the commandline arguments to the program slightly in three ways:
1. `-v` prints INFO level logging
2. `-vv` prints DEBUG level logging
3. `html_path` is now optional. If no html_path is provided, the html is printed to stdout by `extract_tree` or returned as a string by the parse function if being used as a package.


TODO:
- [x] Update README with new args
- [x] switch all prints to logging
- [x] ~~figure out how to silence the pdfbox logs~~