### PR TITLE
Remove "dry_run" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - [@HiromuHota][HiromuHota]: Remove "favor_figures" option and extract everything.
   ([#77](https://github.com/HazyResearch/pdftotree/pull/77))
+- [@HiromuHota][HiromuHota]: Remove "dry_run" option.
+  ([#89](https://github.com/HazyResearch/pdftotree/pull/89))
 
 ### Fixed
 - [@HiromuHota][HiromuHota]: Fix a bug that an html file is not created at a given path.

--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,6 @@ This takes a PDF file as input and produces an hOCR file as output::
                             Path to output hOCR file. If not given, it will be
                             printed to stdout.
       -V, --visualize       Whether to output visualization images
-      -d, --dry-run         Run pdftotree, but do not save any output or print to
-                            console.
       -v, --verbose         Output INFO level logging.
       -vv, --veryverbose    Output DEBUG level logging.
 

--- a/bin/pdftotree
+++ b/bin/pdftotree
@@ -47,13 +47,6 @@ if __name__ == "__main__":
         help="Whether to output visualization images for the tree",
     )
     parser.add_argument(
-        "-d",
-        "--dry-run",
-        dest="dry_run",
-        action="store_true",
-        help="Run pdftotree, but do not save any output or print to console.",
-    )
-    parser.add_argument(
         "-v",
         "--verbose",
         dest="verbose",
@@ -92,10 +85,6 @@ if __name__ == "__main__":
     ch.setFormatter(formatter)
     log.addHandler(ch)
 
-    if args.dry_run:
-        print("This is just a dry run. No hOCR will be output.")
-        args.output = None
-
     # Call the main routine
     result = pdftotree.parse(
         args.pdf_file,
@@ -105,8 +94,7 @@ if __name__ == "__main__":
         args.visualize,
     )
 
-    if result:
-        if not args.dry_run:
-            print(result)
+    if args.output is None:
+        print(result)
     else:
         print("hOCR output to {}".format(args.output))


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

I can't see the reason why this option is required.
If you don't want to overwrite an output file created previously, just print the result to the console.
If you don't want to mess the console with a lengthy result, redirect the output to `/dev/null` like this: `pdftotree tests/input/md.pdf > /dev/null`

**Does your pull request fix any issue.**

N/A

## Description of the proposed changes

Remove "dry_run" option from `pdftotree` command

## Test plan

N/A

## Checklist

* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.md accordingly.
