### PR TITLE
Use the centroid to check if textlines are within a bbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - List a missing "ocrx_line" in the ocr-capabilities metadata field.
   ([#94](https://github.com/HazyResearch/pdftotree/issues/94), [@HiromuHota][HiromuHota])
+- Use the centroid for `isContained` check not to miss cell values.
+  ([#96](https://github.com/HazyResearch/pdftotree/issues/96), [@HiromuHota][HiromuHota])
 
 ## 0.5.0 - 2020-10-13
 

--- a/pdftotree/TreeExtract.py
+++ b/pdftotree/TreeExtract.py
@@ -216,7 +216,7 @@ class TreeExtractor(object):
         return self.font_stats
 
     def get_tree_structure(self, model_type, model) -> Dict[str, Any]:
-        tables = {}
+        tables: Dict[int, List[Tuple(int, int, int, float, float, float, float)]] = {}
         # use vision to get tables
         if model_type == "vision":
             from pdftotree.visual.visual_utils import get_bboxes, predict_heatmap
@@ -334,6 +334,11 @@ class TreeExtractor(object):
     def get_word_boundaries(
         self, mention: LTTextLine
     ) -> List[Tuple[str, float, float, float, float]]:
+        """Split a line of text into words.
+
+        :param mention: a line of text
+        :return: a list of words
+        """
         mention_text = mention.get_text()
         mention_chars: List[Tuple[str, int, int, int, int]] = []
         for obj in mention:

--- a/pdftotree/ml/features.py
+++ b/pdftotree/ml/features.py
@@ -46,12 +46,16 @@ def get_mentions_within_bbox(
     """
     mentions_within_bbox = []
     for mention in mentions:
+        # Compute the centroid
+        xc = int((mention.x0 + mention.x1) / 2)
+        yc = int((mention.y0 + mention.y1) / 2)
         bbox_mention = (
-            int(mention.y0),
-            int(mention.x0),
-            int(mention.y1),
-            int(mention.x1),
+            yc,
+            xc,
+            yc,
+            xc,
         )
+        # See if the centroid is contained by the bbox.
         if isContained(bbox_mention, bbox[-4:]):
             mentions_within_bbox += [mention]
     return mentions_within_bbox

--- a/pdftotree/utils/pdf/pdf_parsers.py
+++ b/pdftotree/utils/pdf/pdf_parsers.py
@@ -8,9 +8,9 @@ import logging
 import math
 import operator
 from builtins import filter, range, str, zip
-from collections import defaultdict
+from collections import Counter, defaultdict
 from functools import cmp_to_key
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from pdfminer.layout import LTTextLine
 from pdfminer.utils import Plane
@@ -725,7 +725,13 @@ def cluster_vertically_aligned_boxes(
         return tables, table_features
 
 
-def parse_tree_structure(elems: PDFElems, font_stat, page_num, ref_page_seen, tables):
+def parse_tree_structure(
+    elems: PDFElems,
+    font_stat: Counter,
+    page_num: int,
+    ref_page_seen: bool,
+    tables_page: List[Tuple[int, int, int, float, float, float, float]],
+) -> Tuple[Dict[str, Any], bool]:
     boxes_segments = elems.segments
     boxes_curves = elems.curves
     boxes_figures = elems.figures
@@ -760,8 +766,6 @@ def parse_tree_structure(elems: PDFElems, font_stat, page_num, ref_page_seen, ta
     figures_page = get_figures(
         mentions, elems.layout.bbox, page_num, boxes_figures, page_width, page_height
     )
-
-    tables_page = tables
 
     # Eliminate tables from these boxes
     boxes: List[LTTextLine] = []

--- a/tests/test_table_detection.py
+++ b/tests/test_table_detection.py
@@ -1,5 +1,7 @@
 """Test table area detection."""
+from bs4 import BeautifulSoup
 
+import pdftotree
 from pdftotree.core import load_model
 from pdftotree.visual.visual_utils import predict_heatmap
 
@@ -18,3 +20,16 @@ def test_vision_model():
 
 
 # TODO: add test_ml_model and test_heuristic_model
+
+
+def test_cell_values_not_missing():
+    output = pdftotree.parse("tests/input/md.pdf")
+    soup = BeautifulSoup(output, "lxml")
+    table = soup.find(class_="ocr_table")
+    assert list(table.find_all("tr")[3].stripped_strings) == [
+        "Erin",
+        "lamb",
+        "madras",
+        "HOT",
+        "$5",
+    ]


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #96 

**Does your pull request fix any issue.**

Fix #96

## Description of the proposed changes

Use the centroid to check if textlines are within a bbox instead of its whole bbox.
This change makes the `isContained` check loose, which tolerates a fluctuating bbox returned from Tabula.

## Test plan

Check if cell values are not missed and extracted.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.md accordingly.
