### PR TITLE
Treat non-breaking space as a white space at get_word_boundaries()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#94](https://github.com/HazyResearch/pdftotree/issues/94), [@HiromuHota][HiromuHota])
 - Use the centroid for `isContained` check not to miss cell values.
   ([#96](https://github.com/HazyResearch/pdftotree/issues/96), [@HiromuHota][HiromuHota])
+- Treat non-breaking space as a white space to prevent "Out of order" warnings.
+  ([#98](https://github.com/HazyResearch/pdftotree/pull/98), [@HiromuHota][HiromuHota])
 
 ## 0.5.0 - 2020-10-13
 

--- a/pdftotree/TreeExtract.py
+++ b/pdftotree/TreeExtract.py
@@ -352,7 +352,7 @@ class TreeExtractor(object):
             curr_word = [word, float("Inf"), float("Inf"), float("-Inf"), float("-Inf")]
             len_idx = 0
             while len_idx < len(word):
-                if mention_chars[char_idx][0] == " ":
+                if mention_chars[char_idx][0] in [" ", "\xa0"]:
                     char_idx += 1
                     continue
                 if word[len_idx] != mention_chars[char_idx][0]:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import os
 from subprocess import PIPE, Popen
 from typing import Optional
@@ -63,6 +62,12 @@ def test_output_should_conform_to_hocr(tmp_path):
         "ocrx_line",
         "ocrx_word",
     ]
+
+
+def test_no_out_of_order(caplog):
+    """Test if no out of order warning is issued."""
+    pdftotree.parse("tests/input/md.pdf")
+    assert "Out of order" not in caplog.text
 
 
 def test_visualize_output(tmp_path):


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

A non-breaking space (`\xa0`) causes "Out of order" warnings at md.pdf

```
$ pip list | grep pdftotree
pdftotree                     0.5.0
$ pdftotree tests/input/md.pdf -v > /dev/null
[INFO] pdftotree.core - Digitized PDF detected, building tree structure...
[INFO] pdftotree.core - Tree structure built, creating html...
[WARNING] pdftotree.TreeExtract - Out of order (Markdown,  )
[WARNING] pdftotree.TreeExtract - Out of order (Markdown, M)
[WARNING] pdftotree.TreeExtract - Out of order (Markdown, a)
[WARNING] pdftotree.TreeExtract - Out of order (Markdown, r)
[WARNING] pdftotree.TreeExtract - Out of order (Markdown, k)
[WARNING] pdftotree.TreeExtract - Out of order (Markdown, d)
[WARNING] pdftotree.TreeExtract - Out of order (Markdown, o)
[WARNING] pdftotree.TreeExtract - Out of order (Markdown, w)
```

**Does your pull request fix any issue.**

N/A

## Description of the proposed changes

Treat non-breaking space as a white space at get_word_boundaries()

## Test plan
A clear and concise description of how you test the new changes.

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.md accordingly.
