### PR TITLE
Embed Base64-Encoded Images Inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Embed base64-encoded images inline. Support starting with JPEG and BMP.
+  ([#99](https://github.com/HazyResearch/pdftotree/pull/99), [@HiromuHota][HiromuHota])
+
 ### Fixed
 - List a missing "ocrx_line" in the ocr-capabilities metadata field.
   ([#94](https://github.com/HazyResearch/pdftotree/issues/94), [@HiromuHota][HiromuHota])

--- a/pdftotree/TreeExtract.py
+++ b/pdftotree/TreeExtract.py
@@ -42,7 +42,9 @@ class TreeExtractor(object):
         self.font_stats: Dict[int, Any] = {}  # key represents page_num
         self.iou_thresh = 0.8
         self.scanned = False
-        self.tree: Dict[int, Any] = {}  # key represents page_num
+        self.tree: Dict[
+            int, Dict[str, Tuple[int, int, int, float, float, float, float]]
+        ] = {}  # key represents page_num
 
     def identify_scanned_page(self, boxes, page_bbox, page_width, page_height):
         plane = Plane(page_bbox)
@@ -292,13 +294,13 @@ class TreeExtractor(object):
         body = doc.createElement("body")
         html.appendChild(body)
         for page_num in self.elems.keys():  # 1-based
-            boxes = []
+            boxes: List[Tuple[str, float, float, float, float]] = []
             for clust in self.tree[page_num]:
                 for (pnum, pwidth, pheight, top, left, bottom, right) in self.tree[
                     page_num
                 ][clust]:
                     boxes += [
-                        [clust.lower().replace(" ", "_"), top, left, bottom, right]
+                        (clust.lower().replace(" ", "_"), top, left, bottom, right)
                     ]
             page = doc.createElement("div")
             page.setAttribute("class", "ocr_page")

--- a/pdftotree/ml/features.py
+++ b/pdftotree/ml/features.py
@@ -3,7 +3,7 @@ from builtins import str
 from collections import defaultdict
 from typing import Any, List
 
-from pdfminer.layout import LTTextLine
+from pdfminer.layout import LTComponent, LTTextLine
 
 from pdftotree.utils.bbox_utils import isContained
 from pdftotree.utils.pdf.pdf_parsers import (
@@ -36,8 +36,8 @@ def get_height_coverage(bbox):
 
 
 def get_mentions_within_bbox(
-    bbox: List[Any], mentions: List[LTTextLine]
-) -> List[LTTextLine]:
+    bbox: List[Any], mentions: List[LTComponent]
+) -> List[LTComponent]:
     """Get textlines within bbox.
 
     :param bbox: a list containing (top, left, bottom, right) in the last 4 digits

--- a/pdftotree/utils/bbox_utils.py
+++ b/pdftotree/utils/bbox_utils.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 TOLERANCE = 5
 
 
@@ -147,3 +149,13 @@ def compute_iou(bbox1, bbox2):
         )
         return float(intersection) / float(union)
     return 0.0
+
+
+def bbox2str(bbox: Tuple[float, float, float, float]) -> str:
+    """Return a string representation suited for hOCR.
+
+    :param bbox: a bounding box (left, top, right, bottom)
+    :return: a string representation for hOCR
+    """
+    (x0, y0, x1, y1) = bbox
+    return f"bbox {int(x0)} {int(y0)} {int(x1)} {int(y1)}"

--- a/pdftotree/utils/pdf/node.py
+++ b/pdftotree/utils/pdf/node.py
@@ -5,6 +5,7 @@ Created on Jun 10, 2016
 """
 import numbers
 from collections import Counter
+from typing import List, Union
 
 from pdfminer.layout import LTComponent, LTCurve, LTFigure, LTLine, LTTextLine
 
@@ -31,7 +32,7 @@ class Node(LTComponent):
     Also holds its data and features.
     """
 
-    def __init__(self, elems):
+    def __init__(self, elems: Union[List[LTComponent], LTComponent]):
         """
         Constructor
         """

--- a/pdftotree/utils/pdf/pdf_parsers.py
+++ b/pdftotree/utils/pdf/pdf_parsers.py
@@ -547,7 +547,7 @@ def cluster_vertically_aligned_boxes(
     nodes = [Node(elems) for elems in clusters]
     node_indices = [i for i, x in enumerate(cid2obj2) if x]
     merge_indices = [i for i in range(len(node_indices))]
-    nodes, merge_indices = merge_nodes(nodes, merge_indices)
+    merge_indices = merge_nodes(nodes, merge_indices)
     # Features
     for idx in range(len(merge_indices)):
         if merge_indices[idx] != idx:
@@ -1036,7 +1036,7 @@ def extract_text_candidates(
     nodes = [Node(elems) for elems in clusters]
     node_indices = [i for i, x in enumerate(cid2obj) if x]
     merge_indices = [i for i in range(len(node_indices))]
-    nodes, merge_indices = merge_nodes(nodes, merge_indices)
+    merge_indices = merge_nodes(nodes, merge_indices)
 
     # Merging Nodes
     new_nodes = []
@@ -1195,11 +1195,11 @@ def get_figures(
         return []
 
     # Convert LTFigure to Node
-    nodes_figures: List[Node] = [Node(fig_box) for fig_box in boxes]
+    nodes: List[Node] = [Node(fig_box) for fig_box in boxes]
 
     # Merge and retain only the most outer nodes
-    merge_indices = list(range(len(nodes_figures)))
-    nodes, merge_indices = merge_nodes(nodes_figures, merge_indices)
+    merge_indices = list(range(len(nodes)))
+    merge_indices = merge_nodes(nodes, merge_indices)
     new_nodes = []
     for idx in range(len(merge_indices)):
         if merge_indices[idx] == idx:
@@ -1212,9 +1212,7 @@ def get_figures(
     return figures
 
 
-def merge_nodes(
-    nodes: List[Node], merge_indices: List[int]
-) -> Tuple[List[Node], List[int]]:
+def merge_nodes(nodes: List[Node], merge_indices: List[int]) -> List[int]:
     """
     Merges overlapping nodes
     """
@@ -1244,7 +1242,7 @@ def merge_nodes(
         for cid_iter in range(len(merge_indices)):
             if merge_indices[cid_iter] == merge_indices[inner_idx]:
                 merge_indices[cid_iter] = merge_indices[best_outer_idx]
-    return nodes, merge_indices
+    return merge_indices
 
 
 def get_most_common_font_pts(mentions, font_stat):

--- a/pdftotree/utils/pdf/pdf_parsers.py
+++ b/pdftotree/utils/pdf/pdf_parsers.py
@@ -1213,8 +1213,11 @@ def get_figures(
 
 
 def merge_nodes(nodes: List[Node], merge_indices: List[int]) -> List[int]:
-    """
-    Merges overlapping nodes
+    """Merges overlapping nodes.
+
+    :param nodes: Nodes to be merged
+    :param merge_indices: Indices of nodes
+    :return: a list of indices, indicating which node is its most outer node.
     """
     # Merge inner boxes to the best outer box
     # nodes.sort(key=Node.area)

--- a/pdftotree/utils/pdf/pdf_parsers.py
+++ b/pdftotree/utils/pdf/pdf_parsers.py
@@ -1200,16 +1200,9 @@ def get_figures(
     # Merge and retain only the most outer nodes
     merge_indices = list(range(len(nodes)))
     merge_indices = merge_nodes(nodes, merge_indices)
-    new_nodes = []
-    for idx in range(len(merge_indices)):
-        if merge_indices[idx] == idx:
-            new_nodes.append(nodes[idx])
+    new_nodes = [node for idx, node in enumerate(nodes) if merge_indices[idx] == idx]
 
-    figures = [
-        (page_num, page_width, page_height) + (node.y0, node.x0, node.y1, node.x1)
-        for node in new_nodes
-    ]
-    return figures
+    return new_nodes
 
 
 def merge_nodes(nodes: List[Node], merge_indices: List[int]) -> List[int]:

--- a/pdftotree/utils/pdf/pdf_parsers.py
+++ b/pdftotree/utils/pdf/pdf_parsers.py
@@ -547,8 +547,7 @@ def cluster_vertically_aligned_boxes(
     nodes = [Node(elems) for elems in clusters]
     node_indices = [i for i, x in enumerate(cid2obj2) if x]
     merge_indices = [i for i in range(len(node_indices))]
-    page_stat = Node(boxes)
-    nodes, merge_indices = merge_nodes(nodes, plane, page_stat, merge_indices)
+    nodes, merge_indices = merge_nodes(nodes, merge_indices)
     # Features
     for idx in range(len(merge_indices)):
         if merge_indices[idx] != idx:
@@ -1033,8 +1032,7 @@ def extract_text_candidates(
     nodes = [Node(elems) for elems in clusters]
     node_indices = [i for i, x in enumerate(cid2obj) if x]
     merge_indices = [i for i in range(len(node_indices))]
-    page_stat = Node(boxes)
-    nodes, merge_indices = merge_nodes(nodes, plane, page_stat, merge_indices)
+    nodes, merge_indices = merge_nodes(nodes, merge_indices)
 
     # Merging Nodes
     new_nodes = []
@@ -1209,8 +1207,7 @@ def get_figures(
     nodes_figures: List[Node] = [Node(fig_box) for fig_box in boxes_figures]
 
     merge_indices = [i for i in range(len(nodes_figures))]
-    page_stat = Node(boxes)
-    nodes, merge_indices = merge_nodes(nodes_figures, plane, page_stat, merge_indices)
+    nodes, merge_indices = merge_nodes(nodes_figures, merge_indices)
 
     # Merging Nodes
     new_nodes = []
@@ -1226,7 +1223,7 @@ def get_figures(
 
 
 def merge_nodes(
-    nodes: List[Node], plane: Plane, page_stat: Node, merge_indices: List[int]
+    nodes: List[Node], merge_indices: List[int]
 ) -> Tuple[List[Node], List[int]]:
     """
     Merges overlapping nodes

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -1,0 +1,11 @@
+"""Test figures."""
+from bs4 import BeautifulSoup
+
+import pdftotree
+
+
+def test_figures():
+    output = pdftotree.parse("tests/input/md.pdf")
+    soup = BeautifulSoup(output, "lxml")
+    imgs = soup.find_all("img")
+    assert len(imgs) == 1

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -9,3 +9,11 @@ def test_figures():
     soup = BeautifulSoup(output, "lxml")
     imgs = soup.find_all("img")
     assert len(imgs) == 1
+
+    output = pdftotree.parse("tests/input/CaseStudy_ACS.pdf")
+    soup = BeautifulSoup(output, "lxml")
+    imgs = soup.find_all("img")
+    # 3 jpg, 2 bmp, 5 total images
+    assert len(imgs) == 5
+    assert len([img for img in imgs if img["src"].startswith("data:image/jpeg")]) == 3
+    assert len([img for img in imgs if img["src"].startswith("data:image/bmp")]) == 2


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

See #88

**Does your pull request fix any issue.**

Close #88

## Description of the proposed changes

Embed base64-encoded images inline. Support starting with JPEG and BMP.

## Test plan

Apply pdftotree to pdfs and see if JPEG and BMP images are extracted.

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.md accordingly.
