### PR TITLE
Do not escape text twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#96](https://github.com/HazyResearch/pdftotree/issues/96), [@HiromuHota][HiromuHota])
 - Treat non-breaking space as a white space to prevent "Out of order" warnings.
   ([#98](https://github.com/HazyResearch/pdftotree/pull/98), [@HiromuHota][HiromuHota])
+- Escape text only once.
+  ([#100](https://github.com/HazyResearch/pdftotree/pull/100), [@HiromuHota][HiromuHota])
 
 ## 0.5.0 - 2020-10-13
 

--- a/pdftotree/TreeExtract.py
+++ b/pdftotree/TreeExtract.py
@@ -1,4 +1,3 @@
-import html
 import logging
 import os
 from functools import cmp_to_key
@@ -398,8 +397,6 @@ class TreeExtractor(object):
             words = self.get_word_boundaries(elem)
             for word in words:
                 top, left, bottom, right = [int(x) for x in word[1:]]
-                # escape special HTML chars
-                text = html.escape(word[0])
 
                 word_element = self.doc.createElement("span")
                 line_element.appendChild(word_element)
@@ -407,7 +404,8 @@ class TreeExtractor(object):
                 word_element.setAttribute(
                     "title", f"bbox {left} {top} {right} {bottom}"
                 )
-                word_element.appendChild(self.doc.createTextNode(text))
+                # No need to escape text here as minidom will do.
+                word_element.appendChild(self.doc.createTextNode(word[0]))
         return element
 
     def get_html_table(self, table: List[float], page_num) -> Optional[Element]:
@@ -468,8 +466,6 @@ class TreeExtractor(object):
                         left = int(word[2])
                         bottom = int(word[3])
                         right = int(word[4])
-                        # escape special HTML chars
-                        text = html.escape(word[0])
 
                         word_element = self.doc.createElement("span")
                         line_element.appendChild(word_element)
@@ -477,5 +473,6 @@ class TreeExtractor(object):
                         word_element.setAttribute(
                             "title", f"bbox {left} {top} {right} {bottom}"
                         )
-                        word_element.appendChild(self.doc.createTextNode(text))
+                        # No need to escape text here as minidom will do.
+                        word_element.appendChild(self.doc.createTextNode(word[0]))
         return table_element

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,22 @@
+"""Test extracted text."""
+import re
+
+from bs4 import BeautifulSoup
+
+import pdftotree
+
+
+def test_text_is_escaped():
+    """Test if text is properly escaped."""
+    output = pdftotree.parse("tests/input/md.pdf")
+    soup = BeautifulSoup(output, "lxml")
+    words = soup.find_all(class_="ocrx_word")
+    # Use str() instead of .text as the latter gives unescaped text.
+    m = re.search(r">(.+?)<", str(words[66]))
+    assert m[1] == "'bar';."
+
+    output = pdftotree.parse("tests/input/112823.pdf")
+    soup = BeautifulSoup(output, "lxml")
+    words = soup.find_all(class_="ocrx_word")
+    m = re.search(r">(.+?)<", str(words[152]))
+    assert m[1] == "&amp;"


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

Currently, a text is escaped twice. As a result, `&` becomes `&amp;amp;`.

**Does your pull request fix any issue.**

N/A

## Description of the proposed changes

Escape text only once

## Test plan

Add tests on extracted text to make sure text is escaped properly.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.md accordingly.
