### PR TITLE
Treat "(cid:%d)" as a possible char to reduce "Out of order" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#98](https://github.com/HazyResearch/pdftotree/pull/98), [@HiromuHota][HiromuHota])
 - Escape text only once.
   ([#100](https://github.com/HazyResearch/pdftotree/pull/100), [@HiromuHota][HiromuHota])
+- Treat "(cid:%d)" as a possible char to reduce "Out of order" warnings.
+  ([#102](https://github.com/HazyResearch/pdftotree/pull/102), [@HiromuHota][HiromuHota])
 
 ## 0.5.0 - 2020-10-13
 

--- a/pdftotree/TreeExtract.py
+++ b/pdftotree/TreeExtract.py
@@ -383,10 +383,11 @@ class TreeExtractor(object):
             curr_word = [word, float("Inf"), float("Inf"), float("-Inf"), float("-Inf")]
             len_idx = 0
             while len_idx < len(word):
-                if mention_chars[char_idx][0] in [" ", "\xa0"]:
+                char: str = mention_chars[char_idx][0]
+                if char in [" ", "\xa0"]:
                     char_idx += 1
                     continue
-                if word[len_idx] != mention_chars[char_idx][0]:
+                if word[len_idx : len_idx + len(char)] != char:
                     logger.warning(
                         "Out of order ({}, {})".format(word, mention_chars[char_idx][0])
                     )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -69,6 +69,9 @@ def test_no_out_of_order(caplog):
     pdftotree.parse("tests/input/md.pdf")
     assert "Out of order" not in caplog.text
 
+    pdftotree.parse("tests/input/paleo.pdf")
+    assert "Out of order" not in caplog.text
+
 
 def test_visualize_output(tmp_path):
     """Test if an output can be visualzied."""


### PR DESCRIPTION
## Description of the problems or issues

**Is your pull request related to a problem? Please describe.**

Related to #33, currently pdftotree produces CID characters like `(cid:176)`.
This is now totally expected behaviour of pdftotree, so "Out of order warning" should not be raised.

**Does your pull request fix any issue.**

N/A

## Description of the proposed changes

Treat "(cid:%d)" as a possible char

## Test plan

Test with paleo.pdf that produces "Out of order" warnings

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.md accordingly.
